### PR TITLE
uses java9 tarball to install oraclejdk9

### DIFF
--- a/version/oraclejdk9.sh
+++ b/version/oraclejdk9.sh
@@ -2,13 +2,11 @@
 
 echo "================ Installing oracle-java9-installer ================="
 
-echo oracle-java9-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections
-add-apt-repository -y ppa:webupd8team/java
-apt-get update
-apt-get install -y oracle-java9-installer
+wget --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/9.0.1+11/jdk-9.0.1_linux-x64_bin.tar.gz
+tar -xzf jdk-9.0.1_linux-x64_bin.tar.gz
+mv jdk-9.0.1 java-9-oracle
 
 update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-9-oracle/bin/java 1
 update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-9-oracle/bin/javac 1
-update-alternatives --set javaws /usr/lib/jvm/java-9-oracle/bin/javaws
 echo 'export JAVA_HOME=/usr/lib/jvm/java-9-oracle' >> $HOME/.bashrc
 echo 'export PATH=$PATH:/usr/lib/jvm/java-9-oracle/bin' >> $HOME/.bashrc


### PR DESCRIPTION
https://github.com/dry-dock/u16javall/issues/13
installing both openjdk9 and oraclejdk9 using `apt-get install` is having issues. installing openjdk9 uninstall oraclejdk9 and vice versa. So, installing oraclejdk using tarball.