### PR TITLE
update oracle jdk 9 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,5 @@ Shippable CI image for Java on Ubuntu 16.04. Available jdk versions:
 
 **Services:**
 
-1. elasticsearch 5.5.0
-2. memcached 1.4.39
-3. mongodb 3.4.6
-4. mysql 5.7.18
-5. neo4j 3.2.2
-6. postgres 9.6.3
-7. rabbitmq 3.6.10
-8. redis 3.2.9
-9. selenium 3.4
-10. sqllite 3.19.3
-11. couchdb 1.6.1
-12. rethinkdb 2.3.5
-13. riak 2.2.3
-14. cassandra 3.11
+use this link http://github.com/dry-dock/u16all to refer to the versions of the services
+

--- a/version/oraclejdk8.sh
+++ b/version/oraclejdk8.sh
@@ -2,11 +2,14 @@
 
 echo "================ Installing oracle-java8-installer ================="
 echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections
+
 add-apt-repository -y ppa:webupd8team/java
 apt-get update
 apt-get install -y oracle-java8-installer
+
 update-alternatives --set java /usr/lib/jvm/java-8-oracle/jre/bin/java
 update-alternatives --set javac /usr/lib/jvm/java-8-oracle/bin/javac
 update-alternatives --set javaws /usr/lib/jvm/java-8-oracle/jre/bin/javaws
+
 echo 'export JAVA_HOME=/usr/lib/jvm/java-8-oracle' >> $HOME/.bashrc
 echo 'export PATH=$PATH:/usr/lib/jvm/java-8-oracle/bin' >> $HOME/.bashrc

--- a/version/oraclejdk9.sh
+++ b/version/oraclejdk9.sh
@@ -2,11 +2,9 @@
 
 echo "================ Installing oracle-java9-installer ================="
 
-pushd /tmp
-wget --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/9.0.1+11/jdk-9.0.1_linux-x64_bin.tar.gz
-tar -xzf jdk-9.0.1_linux-x64_bin.tar.gz
-mv jdk-9.0.1 /usr/lib/jvm/java-9-oracle
-popd
+echo oracle-java9-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections
 
-update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-9-oracle/bin/java 1
-update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-9-oracle/bin/javac 1
+add-apt-repository -y ppa:webupd8team/java
+apt-get update
+apt install oracle-java9-installer
+


### PR DESCRIPTION
fixes - 
https://github.com/dry-dock/u16javall/issues/27
https://github.com/dry-dock/u16javall/issues/26
https://github.com/dry-dock/u16javall/issues/25
https://github.com/dry-dock/u16javall/issues/24
https://github.com/dry-dock/u16javall/issues/23

use apt-get install for java9 (version 9.0.4) 
java 8 will be default jdk
other minor versions will be updated when image is re-built 
